### PR TITLE
fix(exports): Add missing export for json match evaluator

### DIFF
--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -2,6 +2,7 @@ export { exactMatch } from "./exact.js";
 export { createEmbeddingSimilarityEvaluator } from "./string/embedding_similarity.js";
 export { levenshteinDistance } from "./string/levenshtein.js";
 export { createLLMAsJudge } from "./llm.js";
+export { createJsonMatchEvaluator } from "./json/match.js";
 
 export { HALLUCINATION_PROMPT } from "./prompts/hallucination.js";
 export { CORRECTNESS_PROMPT } from "./prompts/correctness.js";


### PR DESCRIPTION
Right now it's not possible to import and use this. This adds the missing export line.