### PR TITLE
feat(python,js): Make input and output optional for LLM as judge

### DIFF
--- a/js/src/llm.ts
+++ b/js/src/llm.ts
@@ -173,8 +173,8 @@ export const _createLLMAsJudgeScorer = (params: {
   const useReasoning = params.useReasoning ?? true;
 
   const getScore = async (params: {
-    inputs: unknown;
-    outputs: unknown;
+    inputs?: unknown;
+    outputs?: unknown;
     referenceOutputs?: unknown;
     [key: string]: unknown;
   }): Promise<SingleResultScorerReturnType> => {

--- a/js/src/llm.ts
+++ b/js/src/llm.ts
@@ -405,8 +405,8 @@ export const createLLMAsJudge = ({
   });
 
   const _wrappedEvaluator = async (inputs: {
-    inputs: unknown;
-    outputs: unknown;
+    inputs?: unknown;
+    outputs?: unknown;
     referenceOutputs?: unknown;
     [key: string]: unknown;
   }) => {

--- a/python/openevals/llm.py
+++ b/python/openevals/llm.py
@@ -139,7 +139,7 @@ def _create_llm_as_judge_scorer(
     def get_score(
         *,
         inputs: Optional[Union[str, dict]] = None,
-        outputs: Union[str, dict],
+        outputs: Optional[Union[str, dict]] = None,
         reference_outputs: Optional[Union[str, dict]] = None,
         **kwargs,
     ):
@@ -286,7 +286,7 @@ def _create_async_llm_as_judge_scorer(
     async def aget_score(
         *,
         inputs: Optional[Union[str, dict]] = None,
-        outputs: Union[str, dict],
+        outputs: Optional[Union[str, dict]] = None,
         reference_outputs: Optional[Union[str, dict]] = None,
         **kwargs,
     ):
@@ -477,8 +477,8 @@ def create_llm_as_judge(
 
     def _wrapped_evaluator(
         *,
-        inputs: dict,
-        outputs: dict,
+        inputs: Optional[dict] = None,
+        outputs: Optional[dict] = None,
         reference_outputs: Optional[dict] = None,
         **kwargs,
     ) -> EvaluatorResult:
@@ -567,8 +567,8 @@ def create_async_llm_as_judge(
 
     async def _wrapped_evaluator(
         *,
-        inputs: dict,
-        outputs: dict,
+        inputs: Optional[dict] = None,
+        outputs: Optional[dict] = None,
         reference_outputs: Optional[dict] = None,
         **kwargs,
     ) -> EvaluatorResult:


### PR DESCRIPTION
Users may not have/want those exact names in a custom prompt