### PR TITLE
docs: document json match nested-object behavior; fix list_match_mode docstring

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ See the [LLM-as-judge](#llm-as-judge) section for more information on how to cus
 
     - [Evaluating structured output with exact match](#evaluating-structured-output-with-exact-match)
     - [Evaluating structured output with LLM-as-a-Judge](#evaluating-structured-output-with-llm-as-a-judge)
+    - [Nested objects](#nested-objects)
 
   </details>
 
@@ -2014,6 +2015,56 @@ Therefore, the list aggregator will return a final score of 0.
 ```
 
 </details>
+
+### Nested objects
+
+Nested object and array values are supported for exact-match evaluation. They are compared by deep equality as a whole value, so the nested value must match exactly.
+
+<details>
+<summary>Python</summary>
+
+```python
+from openevals.json import create_json_match_evaluator
+
+evaluator = create_json_match_evaluator(aggregator="all")
+
+matching_result = evaluator(
+    outputs={"foo": [{"bar": 1}]},
+    reference_outputs={"foo": [{"bar": 1}]},
+)
+mismatching_result = evaluator(
+    outputs={"foo": [{"bar": 2}]},
+    reference_outputs={"foo": [{"bar": 1}]},
+)
+
+print(matching_result[0]["score"])  # 1
+print(mismatching_result[0]["score"])  # 0
+```
+</details>
+
+<details>
+<summary>TypeScript</summary>
+
+```ts
+import { createJsonMatchEvaluator } from "openevals";
+
+const evaluator = createJsonMatchEvaluator({ aggregator: "all" });
+
+const matchingResult = await evaluator({
+  outputs: { foo: [{ bar: 1 }] },
+  referenceOutputs: { foo: [{ bar: 1 }] },
+});
+const mismatchingResult = await evaluator({
+  outputs: { foo: [{ bar: 2 }] },
+  referenceOutputs: { foo: [{ bar: 1 }] },
+});
+
+console.log(matchingResult[0].score); // 1
+console.log(mismatchingResult[0].score); // 0
+```
+</details>
+
+The `rubric` and `exclude_keys`/`excludeKeys` options target top-level keys only. They do not support nested paths such as `foo.bar` or `foo.0.bar`. To grade a nested sub-value with a rubric, either flatten the structure before evaluation or write a rubric entry for the top-level key that describes the expected nested value.
 
 ## Code
 

--- a/python/openevals/json/match.py
+++ b/python/openevals/json/match.py
@@ -427,11 +427,10 @@ def create_json_match_evaluator(
         judge (ModelClient or BaseChatModel): The judge to use for the evaluation.
         model (str): The model to use for the evaluation.
         use_reasoning (bool): Whether to use reasoning for the keys in `rubric`. Defaults to True.
-        match_mode (Literal["subset_of_output", "subset_of_reference", "exact"]): The mode to use for the evaluation.
-            Defaults to "exact". If "exact", the evaluation will match every element of the outputs with a corresponding
-            element of the reference outputs and vice versa. If "subset_of_reference", the evaluation will match every element
-            of the outputs with a corresponding element of the reference outputs. If "subset_of_output", the evaluation will match
-            every element of the reference outputs with a corresponding element of the outputs.
+        list_match_mode (Literal["superset", "subset", "same_elements", "ordered"]): The mode to use for matching list elements.
+            Defaults to "same_elements". If "same_elements", matches every element of outputs with reference_outputs and vice versa.
+            If "subset", matches elements of outputs with reference_outputs. If "superset", matches elements of reference_outputs
+            with outputs. If "ordered", matches elements by their index position.
 
     Returns:
         A function that takes in outputs and reference_outputs and returns an EvaluatorResult or list of EvaluatorResults.
@@ -764,11 +763,10 @@ def create_async_json_match_evaluator(
         judge (ModelClient or BaseChatModel): The judge to use for the evaluation.
         model (str): The model to use for the evaluation.
         use_reasoning (bool): Whether to use reasoning for the keys in `rubric`. Defaults to True.
-        match_mode (Literal["subset_of_output", "subset_of_reference", "exact"]): The mode to use for the evaluation.
-            Defaults to "exact". If "exact", the evaluation will match every element of the outputs with a corresponding
-            element of the reference outputs and vice versa. If "subset_of_reference", the evaluation will match every element
-            of the outputs with a corresponding element of the reference outputs. If "subset_of_output", the evaluation will match
-            every element of the reference outputs with a corresponding element of the outputs.
+        list_match_mode (Literal["superset", "subset", "same_elements", "ordered"]): The mode to use for matching list elements.
+            Defaults to "same_elements". If "same_elements", matches every element of outputs with reference_outputs and vice versa.
+            If "subset", matches elements of outputs with reference_outputs. If "superset", matches elements of reference_outputs
+            with outputs. If "ordered", matches elements by their index position.
 
     Returns:
         A function that takes in outputs and reference_outputs and returns an EvaluatorResult or list of EvaluatorResults.


### PR DESCRIPTION
## Summary
Documents how `create_json_match_evaluator` handles nested values, and fixes a stale docstring.

## Why this matters
#112 asks whether nested objects are supported. They are: nested object/array values are compared via whole-value deep equality in exact match, while `rubric` and `exclude_keys` operate on top-level keys only. The README didn't state this. While verifying, the Python docstring also advertised a `match_mode` parameter (`subset_of_output` / `subset_of_reference` / `exact`) that does not exist — the real parameter is `list_match_mode` (`superset` / `subset` / `same_elements` / `ordered`). The TypeScript docstring was already correct, so this is a Python-only docstring fix plus a README section.

Fixes #112

AI was used for assistance.
