### PR TITLE
feat(simulators): support multiple app messages in multiturn

### DIFF
--- a/js/src/simulators/multiturn.ts
+++ b/js/src/simulators/multiturn.ts
@@ -16,14 +16,13 @@ import {
 
 export { MultiturnSimulationResult };
 
+type MessageUpdate = Messages | Messages[] | { messages: Messages[] };
+
 export type MultiturnSimulationParams = {
   app: (params: {
     inputs: ChatCompletionMessage;
     threadId: string;
-  }) =>
-    | ChatCompletionMessage
-    | BaseMessage
-    | Promise<ChatCompletionMessage | BaseMessage>;
+  }) => MessageUpdate | Promise<MessageUpdate>;
   user:
     | ((params: {
         trajectory: ChatCompletionMessage[];
@@ -49,12 +48,7 @@ type MultiturnSimulatorTrajectory = Record<string, unknown> & {
 };
 
 function _wrap<T extends Record<string, unknown>>(
-  app: (
-    params: T
-  ) =>
-    | ChatCompletionMessage
-    | BaseMessage
-    | Promise<ChatCompletionMessage | BaseMessage>,
+  app: (params: T) => MessageUpdate | Promise<MessageUpdate>,
   runName: string,
   threadId: string
 ) {
@@ -79,7 +73,7 @@ function _coerceAndAssignIdToMessage(
 
 function _trajectoryReducer(
   currentTrajectory: MultiturnSimulatorTrajectory | null,
-  newUpdate: ChatCompletionMessage,
+  newUpdate: MessageUpdate,
   updateSource: "app" | "user",
   turnCounter: number
 ): MultiturnSimulatorTrajectory {
@@ -190,8 +184,8 @@ function _createStaticSimulatedUser(
  *
  * Conversation trajectories are represented as lists of message objects with "role" and "content" keys.
  * The "app" param you provide will receive the next message in sequence as an input, and should
- * return a message. Internally, the simulation will dedupe these messages by id and merge them into
- * a complete trajectory.
+ * return a message, list of messages, or object with a "messages" key. Internally, the simulation
+ * will dedupe these messages by id and merge them into a complete trajectory.
  *
  * Once "maxTurns" is reached or a provided stopping condition is met, the final trajectory
  * will be passed to provided trajectory evaluators, which will receive the final trajectory
@@ -201,7 +195,7 @@ function _createStaticSimulatedUser(
  * which will be passed directly through to the provided evaluators.
  *
  * @param {Object} params - Configuration parameters for the simulator
- * @param {(params: {inputs: ChatCompletionMessage, threadId: string}) => ChatCompletionMessage | Promise<ChatCompletionMessage>} params.app - Your application. Can be either a LangChain Runnable or a
+ * @param {(params: {inputs: ChatCompletionMessage, threadId: string}) => ChatCompletionMessage | ChatCompletionMessage[] | { messages: ChatCompletionMessage[] } | Promise<ChatCompletionMessage | ChatCompletionMessage[] | { messages: ChatCompletionMessage[] }>} params.app - Your application. Can be either a LangChain Runnable or a
  *        callable that takes the current conversation trajectory and returns
  *        a message.
  * @param {(params: {trajectory: ChatCompletionMessage[], turnCounter: number, threadId: string}) => ChatCompletionMessage | Promise<ChatCompletionMessage> | (string | Messages)[]} params.user - The simulated user. Can be:
@@ -285,7 +279,9 @@ export const runMultiturnSimulation = async (
           threadId,
         });
 
-        const currentInputs = _coerceAndAssignIdToMessage(rawInputs);
+        const currentInputs = _coerceAndAssignIdToMessage(
+          rawInputs as ChatCompletionMessage | BaseMessage
+        );
 
         currentReducedTrajectory = _trajectoryReducer(
           currentReducedTrajectory,
@@ -299,13 +295,11 @@ export const runMultiturnSimulation = async (
           threadId,
         });
 
-        const currentOutputs = _coerceAndAssignIdToMessage(rawOutputs);
-
         turnCounter += 1;
 
         currentReducedTrajectory = _trajectoryReducer(
           currentReducedTrajectory,
-          currentOutputs,
+          rawOutputs,
           "app",
           turnCounter
         );

--- a/js/src/simulators/tests/multiturn.test.ts
+++ b/js/src/simulators/tests/multiturn.test.ts
@@ -13,6 +13,49 @@ import type { ChatCompletionMessage } from "../../index.js";
 
 ls.describe("Multiturn simulator", () => {
   ls.test(
+    "multiturn_app_can_return_multiple_messages",
+    {
+      inputs: {},
+    },
+    async () => {
+      const app = async ({
+        inputs,
+      }: {
+        inputs: ChatCompletionMessage;
+        threadId: string;
+      }) => {
+        return [
+          {
+            role: "assistant" as const,
+            content: "Let me check that.",
+            id: "assistant-1",
+          },
+          {
+            role: "assistant" as const,
+            content: `Final answer for ${inputs.content}`,
+            id: "assistant-2",
+          },
+        ];
+      };
+
+      const result = await runMultiturnSimulation({
+        app,
+        user: ["hello"],
+        maxTurns: 1,
+        threadId: "multiple-app-responses",
+      });
+
+      expect(
+        result.trajectory.map(({ role, content }) => ({ role, content }))
+      ).toEqual([
+        { role: "user", content: "hello" },
+        { role: "assistant", content: "Let me check that." },
+        { role: "assistant", content: "Final answer for hello" },
+      ]);
+    }
+  );
+
+  ls.test(
     "multiturn_failure",
     {
       inputs: {

--- a/python/openevals/simulators/multiturn.py
+++ b/python/openevals/simulators/multiturn.py
@@ -1,6 +1,6 @@
 import uuid
 import asyncio
-from typing import Any, Awaitable, Callable, Literal, Optional, Union
+from typing import Any, Awaitable, Callable, Literal, Optional, Union, cast
 from openevals.types import (
     SimpleEvaluator,
     SimpleAsyncEvaluator,
@@ -18,6 +18,8 @@ from langsmith import traceable
 
 from langchain_core.messages import BaseMessage, BaseMessageChunk
 
+MessageUpdate = Union[Messages, list[Messages], dict]
+
 
 def _wrap(app: Callable[..., Any], run_name: str, thread_id: str) -> Callable:
     @traceable(name=run_name)
@@ -27,9 +29,7 @@ def _wrap(app: Callable[..., Any], run_name: str, thread_id: str) -> Callable:
     return _wrap_app
 
 
-def _awrap(
-    app: Callable[..., Awaitable[Any]], run_name: str, thread_id: str
-) -> Callable:
+def _awrap(app: Callable[..., Any], run_name: str, thread_id: str) -> Callable:
     @traceable(name=run_name)
     async def _wrap_app(inputs: ChatCompletionMessage, **kwargs):
         if asyncio.iscoroutinefunction(app):
@@ -50,7 +50,7 @@ def _coerce_and_assign_id_to_message(
 
 def _trajectory_reducer(
     current_trajectory: Optional[dict],
-    new_update: ChatCompletionMessage,
+    new_update: MessageUpdate,
     *,
     update_source: Literal["app", "user"],
     turn_counter: Optional[int] = None,
@@ -85,7 +85,7 @@ def _trajectory_reducer(
         current_trajectory = {"trajectory": []}
 
     try:
-        coerced_new_update = _normalize_to_openai_messages_list(new_update)
+        coerced_new_update = _normalize_to_openai_messages_list(cast(Any, new_update))
     except ValueError:
         raise ValueError(
             f"Received unexpected trajectory update from '{update_source}': {str(new_update)}. Expected a message, list of messages, or dictionary with a 'messages' key containing messages."
@@ -130,7 +130,7 @@ def _create_static_simulated_user(
 @traceable(name="multiturn_simulator")
 def run_multiturn_simulation(
     *,
-    app: Callable[[ChatCompletionMessage], ChatCompletionMessage],
+    app: Callable[[ChatCompletionMessage], MessageUpdate],
     user: Union[
         Callable[[ChatCompletionMessage], ChatCompletionMessage],
         list[Union[str, Messages]],
@@ -228,11 +228,10 @@ def run_multiturn_simulation(
             turn_counter=turn_counter,
         )
         raw_outputs = wrapped_app(current_inputs)
-        current_outputs = _coerce_and_assign_id_to_message(raw_outputs)
         turn_counter += 1
         current_reduced_trajectory = _trajectory_reducer(
             current_reduced_trajectory,
-            current_outputs,
+            raw_outputs,
             update_source="app",
             turn_counter=turn_counter,
         )
@@ -263,7 +262,9 @@ def run_multiturn_simulation(
 @traceable(name="multiturn_simulator")
 async def run_multiturn_simulation_async(
     *,
-    app: Callable[[ChatCompletionMessage], Awaitable[ChatCompletionMessage]],
+    app: Callable[
+        [ChatCompletionMessage], Union[Awaitable[MessageUpdate], MessageUpdate]
+    ],
     user: Union[
         Callable[[ChatCompletionMessage], Awaitable[ChatCompletionMessage]],
         list[Union[str, Messages]],
@@ -361,11 +362,10 @@ async def run_multiturn_simulation_async(
             turn_counter=turn_counter,
         )
         raw_outputs = await wrapped_app(current_inputs)
-        current_outputs = _coerce_and_assign_id_to_message(raw_outputs)
         turn_counter += 1
         current_reduced_trajectory = _trajectory_reducer(
             current_reduced_trajectory,
-            current_outputs,
+            raw_outputs,
             update_source="app",
             turn_counter=turn_counter,
         )

--- a/python/tests/simulators/test_multiturn.py
+++ b/python/tests/simulators/test_multiturn.py
@@ -29,6 +29,64 @@ import pytest
 
 # ── sync: unique patterns ──────────────────────────────────────────────────────
 
+
+def test_multiturn_app_can_return_multiple_messages():
+    def app(inputs: ChatCompletionMessage, *, thread_id: str):
+        return [
+            {"role": "assistant", "content": "Let me check that.", "id": "assistant-1"},
+            {
+                "role": "assistant",
+                "content": f"Final answer for {inputs['content']}",
+                "id": "assistant-2",
+            },
+        ]
+
+    res = run_multiturn_simulation(
+        app=app,
+        user=["hello"],
+        max_turns=1,
+        thread_id="multiple-app-responses",
+    )
+
+    assert [(msg["role"], msg["content"]) for msg in res["trajectory"]] == [
+        ("user", "hello"),
+        ("assistant", "Let me check that."),
+        ("assistant", "Final answer for hello"),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_multiturn_async_app_can_return_multiple_messages():
+    async def app(inputs: ChatCompletionMessage, *, thread_id: str):
+        return {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "Searching records.",
+                    "id": "assistant-1",
+                },
+                {
+                    "role": "assistant",
+                    "content": f"Async final answer for {inputs['content']}",
+                    "id": "assistant-2",
+                },
+            ]
+        }
+
+    res = await run_multiturn_simulation_async(
+        app=app,
+        user=["hello"],
+        max_turns=1,
+        thread_id="multiple-async-app-responses",
+    )
+
+    assert [(msg["role"], msg["content"]) for msg in res["trajectory"]] == [
+        ("user", "hello"),
+        ("assistant", "Searching records."),
+        ("assistant", "Async final answer for hello"),
+    ]
+
+
 @pytest.mark.langsmith
 def test_multiturn_message_with_openai():
     """Sync raw OpenAI client app; agent refuses refunds so user is unsatisfied."""
@@ -75,8 +133,8 @@ def test_multiturn_message_with_openai():
     assert not res["evaluator_results"][0]["score"]
 
 
-
 # ── async tests ────────────────────────────────────────────────────────────────
+
 
 @pytest.mark.asyncio
 @pytest.mark.langsmith


### PR DESCRIPTION
## Summary
- allow multiturn simulator apps to return a single message, a list of messages, or an object with a `messages` list
- preserve the existing single-message app input contract while merging all app output messages into the trajectory in order
- add Python sync/async regressions and a TypeScript regression for multi-message app responses

Fixes #111.

## Verification
- RED: `uv run pytest tests/simulators/test_multiturn.py::test_multiturn_app_can_return_multiple_messages tests/simulators/test_multiturn.py::test_multiturn_async_app_can_return_multiple_messages -q` failed because app output lists / `{messages: [...]}` were coerced as a single message before the reducer
- RED: `yarn test src/simulators/tests/multiturn.test.ts -t multiturn_app_can_return_multiple_messages` failed with `Received unexpected trajectory update from app` after the list was coerced into an object
- `uv run pytest tests/simulators/test_multiturn.py -q -m 'not langsmith'`
- `uv run pyright openevals/simulators/multiturn.py`
- `uv run ruff check openevals/simulators/multiturn.py tests/simulators/test_multiturn.py`
- `uv run ruff format --check openevals/simulators/multiturn.py tests/simulators/test_multiturn.py`
- `yarn test src/simulators/tests/multiturn.test.ts -t multiturn_app_can_return_multiple_messages`
- `yarn prettier --check src/simulators/multiturn.ts src/simulators/tests/multiturn.test.ts`
- `yarn tsc --noEmit --project tsconfig.json`
- `git diff --check`

Note: `yarn eslint src/simulators/multiturn.ts src/simulators/tests/multiturn.test.ts` currently fails before linting this patch with `Error while loading rule import/no-extraneous-dependencies: (0, _minimatch2.default) is not a function` under the local installed dependency tree.