### PR TITLE
Fix JSON superset matching with empty outputs

### DIFF
--- a/python/openevals/json/match.py
+++ b/python/openevals/json/match.py
@@ -108,6 +108,7 @@ def _prepare_parameters(
             matched_references = set()
 
             for i, ref_item in enumerate(reference_outputs):
+                best_match_idx = None
                 best_match_score = -1
 
                 # Try each available output item

--- a/python/tests/test_json.py
+++ b/python/tests/test_json.py
@@ -508,6 +508,18 @@ def test_json_match_mode_subset_outputs():
 
 
 @pytest.mark.langsmith
+def test_json_match_mode_superset_empty_outputs():
+    evaluator = create_json_match_evaluator(
+        list_aggregator="average",
+        aggregator="average",
+        list_match_mode="superset",
+    )
+    result = evaluator(outputs=[], reference_outputs=[{"a": 1}])
+    assert result[0]["key"] == "json_match:average"
+    assert result[0]["score"] == 0
+
+
+@pytest.mark.langsmith
 def test_json_match_mode_subset_reference():
     outputs = [
         {"a": 1},

--- a/python/tests/test_json_async.py
+++ b/python/tests/test_json_async.py
@@ -514,6 +514,19 @@ async def test_json_match_mode_subset_outputs():
 
 @pytest.mark.langsmith
 @pytest.mark.asyncio
+async def test_json_match_mode_superset_empty_outputs():
+    evaluator = create_async_json_match_evaluator(
+        list_aggregator="average",
+        aggregator="average",
+        list_match_mode="superset",
+    )
+    result = await evaluator(outputs=[], reference_outputs=[{"a": 1}])
+    assert result[0]["key"] == "json_match:average"
+    assert result[0]["score"] == 0
+
+
+@pytest.mark.langsmith
+@pytest.mark.asyncio
 async def test_json_match_mode_subset_reference():
     outputs = [
         {"a": 1},


### PR DESCRIPTION
## Summary

Return a zero score when JSON superset matching receives an empty output list and a non-empty reference list, instead of raising an internal `UnboundLocalError`.

## Problem and trigger

```python
evaluator = create_json_match_evaluator(
    list_aggregator="average",
    aggregator="average",
    list_match_mode="superset",
)
evaluator(outputs=[], reference_outputs=[{"a": 1}])
```

Actual behavior: `UnboundLocalError: cannot access local variable 'best_match_idx'`.

Expected behavior: the missing reference item is treated as unmatched and the evaluator returns `json_match:average` with score `0`, consistent with the other list matching modes.

## Root cause

The superset branch initialized `best_match_idx` only inside the loop over available outputs. With an empty output list that loop never runs, but the variable is read afterward.

## Fix

Initialize `best_match_idx` to `None` for each reference item. This lets the existing unmatched-reference path record the missing item and calculate a zero score.

## Regression tests

Added equivalent synchronous and asynchronous public-API tests for empty outputs with a non-empty reference list. Both tests fail with the `UnboundLocalError` before the fix and pass afterward.

## Validation

- `LANGSMITH_TEST_TRACKING=false python -m pytest tests/test_json.py::test_json_match_mode_superset_empty_outputs tests/test_json_async.py::test_json_match_mode_superset_empty_outputs -q` — 2 passed
- `LANGSMITH_TEST_TRACKING=false python -m pytest tests/test_json.py tests/test_json_async.py -k 'superset or subset_outputs or subset_reference' -q` — 6 passed
- Broader credential-free JSON matcher selection — 55 passed; 17 credential-dependent tests excluded
- `ruff format --check openevals/json/match.py tests/test_json.py tests/test_json_async.py` — passed
- `python -m compileall -q openevals` — passed
- `git diff --check` — passed

Full JSON integration tests include OpenAI and LangSmith calls and therefore require repository credentials. Repository-wide Ruff, mypy, and pyright currently report pre-existing findings in unchanged code; this change adds only one local initialization and introduces no new finding.

## Compatibility

The change only affects `list_match_mode="superset"` with no available output item. Non-empty matching and other list matching modes are unchanged. No API or dependency changes.

## AI assistance

AI assistance was used for investigation and implementation. The public API failure was reproduced before the fix, regression tests were verified to fail before and pass after, related semantics were compared across list modes, and the final diff received an independent agent review.
