### PR TITLE
chore: add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns: ["*"]
+        update-types:
+          - "major"
+
+  - package-ecosystem: "uv"
+    directory: "/python"
+    schedule:
+      interval: "monthly"
+    versioning-strategy: "increase"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns: ["*"]
+        update-types:
+          - "major"
+
+  - package-ecosystem: "npm"
+    directory: "/js"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns: ["*"]
+        update-types:
+          - "major"
+
+  - package-ecosystem: "npm"
+    directory: "/sandbox/e2b"
+    schedule:
+      interval: "monthly"
+    groups:
+      minor-and-patch:
+        patterns: ["*"]
+        update-types:
+          - "minor"
+          - "patch"
+      major:
+        patterns: ["*"]
+        update-types:
+          - "major"


### PR DESCRIPTION
## Summary

- add monthly Dependabot coverage for GitHub Actions
- add monthly uv coverage for the maintained Python package with bounds-preserving `increase` strategy
- add monthly npm coverage for the JS package and maintained E2B sandbox template
- group major updates separately from minor/patch updates

## Validation

- parsed `.github/dependabot.yml` with Ruby YAML
- verified expected ecosystem/directory roots and uv versioning strategy
- `git diff --check`
- confirmed the PR changes only `.github/dependabot.yml`